### PR TITLE
Add support for asynchronous transports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## Unreleased
+
+- Add support for asynchronous transports via logger.drain
+
 ## 3.0.7
 
 - Add node v20 to testing matrix

--- a/README.md
+++ b/README.md
@@ -498,9 +498,16 @@ If one or more of the transports is asynchronous and you want to ensure all mess
 
 ```js
 ["SIGINT", "SIGTERM"].forEach((signal) => {
-  process.once(signal, async () => {
-    await logger.drain(1000);
-    process.exit();
+  process.once(signal, () => {
+    logger
+      .drain(1000)
+      .then(() => {
+        process.exit();
+      })
+      .catch((err) => {
+        console.error(err);
+        process.exit(1);
+      });
   });
 });
 ```

--- a/README.md
+++ b/README.md
@@ -491,3 +491,18 @@ logger.info("How blissful it is, for one who has nothing", {
   env: process.env.NODE_ENV,
 });
 ```
+
+### Asynchronous Transports
+
+If one or more of the transports is asynchronous and you want to ensure all messages have been written before terminating your application, you must wait for the `logger.drain` method to yield. This method takes an optional timeout specified in milliseconds. e.g.
+
+```js
+["SIGINT", "SIGTERM"].forEach((signal) => {
+  process.once(signal, async () => {
+    await logger.drain(1000);
+    process.exit();
+  });
+});
+```
+
+Once you have called `logger.drain` any new logged messages will be suppressed without error and calling `logger.drain` repeatedly will yield the original promise.

--- a/README.md
+++ b/README.md
@@ -497,18 +497,16 @@ logger.info("How blissful it is, for one who has nothing", {
 If one or more of the transports is asynchronous and you want to ensure all messages have been written before terminating your application, you must wait for the `logger.drain` method to yield. This method takes an optional timeout specified in milliseconds. e.g.
 
 ```js
-["SIGINT", "SIGTERM"].forEach((signal) => {
-  process.once(signal, () => {
-    logger
-      .drain(1000)
-      .then(() => {
-        process.exit();
-      })
-      .catch((err) => {
-        console.error(err);
-        process.exit(1);
-      });
-  });
+process.once("SIGTERM", () => {
+  logger
+    .drain(1000)
+    .then(() => {
+      process.exit();
+    })
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
 });
 ```
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,6 +29,7 @@ export class Logger {
   error(context: Error): void;
   enable(): void;
   disable(): void;
+  drain(timeout?: number): Promise<void>;
 }
 
 export const processors: {

--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -55,7 +55,7 @@ module.exports = class Logger {
             reject(new Error("Timedout waiting for logger to drain"));
           });
         const waitUntilDrained = () => {
-          if (this._promises.size > 0) return setImmediate(waitUntilDrained);
+          if (this._promises.size > 0) return setTimeout(waitUntilDrained, 10).unref();
           clearTimeout(timerId);
           resolve();
         };

--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -77,9 +77,11 @@ module.exports = class Logger {
 
   _output(level, record) {
     this._transports.forEach((transport) => {
-      const p = transport(level, record) || Promise.resolve();
-      this._promises.add(p);
-      p.then(() => this._promises.delete(p));
+      const result = transport(level, record);
+      if (result instanceof Promise) {
+        this._promises.add(result);
+        result.then(() => this._promises.delete(result));
+      }
     });
   }
 };

--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -14,6 +14,8 @@ module.exports = class Logger {
     this._transports = transports;
     this._threshold = level;
     this._disabled = false;
+    this._promises = new Set();
+    this._draining = null;
 
     Level.decorate(this);
   }
@@ -27,7 +29,7 @@ module.exports = class Logger {
   }
 
   log(level, ...args) {
-    if (this._disabled || !level.satisfies(this._threshold)) return;
+    if (this._draining || this._disabled || !level.satisfies(this._threshold)) return;
 
     let message;
     let ctx = {};
@@ -43,6 +45,26 @@ module.exports = class Logger {
     this._output({ level, record });
   }
 
+  drain(timeout) {
+    this._draining =
+      this._draining ||
+      new Promise((resolve, reject) => {
+        const timerId =
+          timeout &&
+          setTimeout(() => {
+            reject(new Error("Timedout waiting for logger to drain"));
+          });
+        const waitUntilDrained = () => {
+          if (this._promises.size > 0) return setImmediate(waitUntilDrained);
+          clearTimeout(timerId);
+          resolve();
+        };
+        waitUntilDrained();
+      });
+
+    return this._draining;
+  }
+
   _process({ level, message, ctx }) {
     return this._processors.reduce(
       (record, processor) => {
@@ -55,7 +77,9 @@ module.exports = class Logger {
 
   _output(level, record) {
     this._transports.forEach((transport) => {
-      transport(level, record);
+      const p = transport(level, record) || Promise.resolve();
+      this._promises.add(p);
+      p.then(() => this._promises.delete(p));
     });
   }
 };

--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -14,7 +14,7 @@ module.exports = class Logger {
     this._transports = transports;
     this._threshold = level;
     this._disabled = false;
-    this._promises = new Set();
+    this._pendingTransports = new Set();
     this._draining = null;
 
     Level.decorate(this);
@@ -46,21 +46,21 @@ module.exports = class Logger {
   }
 
   drain(timeout) {
-    this._draining =
-      this._draining ||
-      new Promise((resolve, reject) => {
-        const timerId =
-          timeout &&
-          setTimeout(() => {
-            reject(new Error("Timedout waiting for logger to drain"));
-          });
-        const waitUntilDrained = () => {
-          if (this._promises.size > 0) return setTimeout(waitUntilDrained, 10).unref();
-          clearTimeout(timerId);
-          resolve();
-        };
-        waitUntilDrained();
-      });
+    if (this._draining) return this._draining;
+
+    this._draining = new Promise((resolve, reject) => {
+      const timerId =
+        timeout &&
+        setTimeout(() => {
+          reject(new Error("Timedout waiting for logger to drain"));
+        });
+      const waitUntilDrained = () => {
+        if (this._pendingTransports.size > 0) return setTimeout(waitUntilDrained, 10).unref();
+        clearTimeout(timerId);
+        resolve();
+      };
+      waitUntilDrained();
+    });
 
     return this._draining;
   }
@@ -79,8 +79,8 @@ module.exports = class Logger {
     this._transports.forEach((transport) => {
       const result = transport(level, record);
       if (result instanceof Promise) {
-        this._promises.add(result);
-        result.then(() => this._promises.delete(result));
+        this._pendingTransports.add(result);
+        result.then(() => this._pendingTransports.delete(result));
       }
     });
   }

--- a/test/Logger.test.js
+++ b/test/Logger.test.js
@@ -1,4 +1,5 @@
-const { deepStrictEqual: eq, ok, match } = require("assert");
+const { EOL } = require("os");
+const { deepStrictEqual: eq, ok, match, rejects } = require("assert");
 const { TestOutputStream } = require("./support");
 const { Level, Logger, processors, transports } = require("..");
 
@@ -31,7 +32,7 @@ describe("Logger", () => {
     });
   };
 
-  const errorPosition = "38:24";
+  const errorPosition = "39:24";
 
   const runScenario = (ts, scenario) => {
     const logger = newLogger(ts);
@@ -269,5 +270,150 @@ describe("Logger", () => {
 
     logger.info("Tripitaka rocks!", { x: "y" });
     eq(streams[Level.INFO.name].lines.length, 4);
+  });
+
+  it("should wait for asynchronous transports to drain", async () => {
+    const testOutputStream = new TestOutputStream();
+    const transport = ({ record }) => {
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          testOutputStream.write(record);
+          testOutputStream.write(EOL);
+          resolve();
+        }, 100);
+      });
+    };
+
+    const logger = new Logger({
+      transports: [transport],
+    });
+
+    logger.info("Tripitaka rocks!");
+
+    eq(testOutputStream.lines.length, 0);
+
+    await logger.drain();
+
+    eq(testOutputStream.lines.length, 1);
+  });
+
+  it("should timeout if asynchronous transports take too long to drain", async () => {
+    let resolve;
+    const transport = () => {
+      return new Promise((_resolve) => {
+        resolve = _resolve;
+      });
+    };
+
+    const logger = new Logger({
+      transports: [transport],
+    });
+
+    logger.info("Tripitaka rocks!");
+
+    await rejects(
+      () => logger.drain(100),
+      (err) => {
+        eq(err.message, "Timedout waiting for logger to drain");
+        resolve();
+        return true;
+      }
+    );
+  });
+
+  it("should not wait when messages have already drained", async () => {
+    const testOutputStream = new TestOutputStream();
+    const transport = ({ record }) => {
+      return new Promise((resolve) => {
+        testOutputStream.write(record);
+        testOutputStream.write(EOL);
+        resolve();
+      });
+    };
+
+    const logger = new Logger({
+      transports: [transport],
+    });
+
+    logger.info("Tripitaka rocks!");
+
+    eq(testOutputStream.lines.length, 1);
+
+    const before = Date.now();
+    await logger.drain();
+    const after = Date.now();
+
+    ok(after - before <= 10);
+  });
+
+  it("should not wait when there were never any messages", async () => {
+    const testOutputStream = new TestOutputStream();
+    const transport = ({ record }) => {
+      return new Promise((resolve) => {
+        testOutputStream.write(record);
+        testOutputStream.write(EOL);
+        resolve();
+      });
+    };
+
+    const logger = new Logger({
+      transports: [transport],
+    });
+
+    const before = Date.now();
+    await logger.drain();
+    const after = Date.now();
+
+    ok(after - before <= 10);
+  });
+
+  it("should suppress messages logged while draining", async () => {
+    const testOutputStream = new TestOutputStream();
+    const transport = ({ record }) => {
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          testOutputStream.write(record);
+          testOutputStream.write(EOL);
+          resolve();
+        }, 100);
+      });
+    };
+
+    const logger = new Logger({
+      transports: [transport],
+    });
+
+    logger.info("Tripitaka rocks!");
+
+    const drained = logger.drain();
+
+    logger.info("Tripitaka sucks!");
+
+    await drained;
+
+    eq(testOutputStream.lines.length, 1);
+  });
+
+  it("should tollerate repeated requests to drain", async () => {
+    const testOutputStream = new TestOutputStream();
+    const transport = ({ record }) => {
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          testOutputStream.write(record);
+          testOutputStream.write(EOL);
+          resolve();
+        }, 100);
+      });
+    };
+
+    const logger = new Logger({
+      transports: [transport],
+    });
+
+    logger.info("Tripitaka rocks!");
+
+    await Promise.all(new Array(10).fill().map(() => logger.drain()));
+
+    eq(testOutputStream.lines.length, 1);
   });
 });

--- a/test/Logger.test.js
+++ b/test/Logger.test.js
@@ -297,6 +297,23 @@ describe("Logger", () => {
     eq(testOutputStream.lines.length, 1);
   });
 
+  it("should tolerate transports that return junk", async () => {
+    const testOutputStream = new TestOutputStream();
+    const transport = ({ record }) => {
+      testOutputStream.write(record);
+      testOutputStream.write(EOL);
+      return "not a promise";
+    };
+
+    const logger = new Logger({
+      transports: [transport],
+    });
+
+    logger.info("Tripitaka rocks!");
+
+    eq(testOutputStream.lines.length, 1);
+  });
+
   it("should timeout if asynchronous transports take too long to drain", async () => {
     let resolve;
     const transport = () => {

--- a/test/Logger.test.js
+++ b/test/Logger.test.js
@@ -343,7 +343,7 @@ describe("Logger", () => {
     await logger.drain();
     const after = Date.now();
 
-    ok(after - before <= 10);
+    ok(after - before <= 20);
   });
 
   it("should not wait when there were never any messages", async () => {


### PR DESCRIPTION
This PR adds support for asynchronous transports. The goal was to do be able to wait until the transport yields without having to `await` each trace/debut/info/warn/error function.

The solution I've come up is to add an asynchronous `logger.drain` method which can be awaited. e.g.

```js
['SIGINT', 'SIGTERM'].forEach((signal) => {
  process.once(signal => {
    logger.drain(500) // calling drain twice is probably harmless to Tripitaka, but will resolve both times
      .then(() => process.exit());
      .catch(() => process.exit(1));
  });
});
```

Internally the logger stashes any promises returned by a transport in a set. When the promise resolves it is removed from the set. The `logger.drain` method resolves when the set is empty.

After calling `logger.drain` any new messages are suppressed without warning. This is to prevent some bright spark listening to the warning and logging it causing a log storm.

I have a few concerns with my implementation so please read my self review carefully.