### PR TITLE
Replace logger.drain with logger.waitForTransports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## Unreleased
+
+- Replace logger.drain with logger.waitForTransports, which does not block subsequent messages from being logged
+
 ## 3.1.0
 
 - Add support for asynchronous transports via logger.drain

--- a/README.md
+++ b/README.md
@@ -494,12 +494,12 @@ logger.info("How blissful it is, for one who has nothing", {
 
 ### Asynchronous Transports
 
-If one or more of the transports is asynchronous and you want to ensure all messages have been written before terminating your application, you must wait for the `logger.drain` method to yield. This method takes an optional timeout specified in milliseconds. e.g.
+If one or more of the transports is asynchronous and you want to ensure all messages have been written before terminating your application, you must wait for the `logger.waitForTransports` method to yield. This method takes an optional timeout specified in milliseconds. e.g.
 
 ```js
 process.once("SIGTERM", () => {
   logger
-    .drain(1000)
+    .waitForTransports(1000)
     .then(() => {
       process.exit();
     })
@@ -510,4 +510,4 @@ process.once("SIGTERM", () => {
 });
 ```
 
-Once you have called `logger.drain` any new logged messages will be suppressed without error and calling `logger.drain` repeatedly will yield the original promise.
+Once you have called `logger.waitForTransports` any subsequent messages will be still be accepted and will prevent the promise from resolving until they have been processed. If your application logs intensively `logger.waitForTransports` could therefore block indefinitely unless you specify a timeout.

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,7 @@ export class Logger {
   error(context: Error): void;
   enable(): void;
   disable(): void;
-  drain(timeout?: number): Promise<void>;
+  waitForTransports(timeout?: number): Promise<void>;
 }
 
 export const processors: {

--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -15,7 +15,6 @@ module.exports = class Logger {
     this._threshold = level;
     this._disabled = false;
     this._pendingTransports = new Set();
-    this._draining = null;
 
     Level.decorate(this);
   }
@@ -29,7 +28,7 @@ module.exports = class Logger {
   }
 
   log(level, ...args) {
-    if (this._draining || this._disabled || !level.satisfies(this._threshold)) return;
+    if (this._disabled || !level.satisfies(this._threshold)) return;
 
     let message;
     let ctx = {};
@@ -45,14 +44,12 @@ module.exports = class Logger {
     this._output({ level, record });
   }
 
-  drain(timeout) {
-    if (this._draining) return this._draining;
-
-    this._draining = new Promise((resolve, reject) => {
+  waitForTransports(timeout) {
+    return new Promise((resolve, reject) => {
       const timerId =
         timeout &&
         setTimeout(() => {
-          reject(new Error("Timedout waiting for logger to drain"));
+          reject(new Error("Timedout waiting for transports to finish"));
         });
       const waitUntilDrained = () => {
         if (this._pendingTransports.size > 0) return setTimeout(waitUntilDrained, 10).unref();
@@ -61,8 +58,6 @@ module.exports = class Logger {
       };
       waitUntilDrained();
     });
-
-    return this._draining;
   }
 
   _process({ level, message, ctx }) {


### PR DESCRIPTION
logger.drain was flawed because it discarded subsequent messages being logged, and did not work well for the lambda context it was introduced for. Instead I've replaced it with logger.waitForTransports, which continues to accept new log messages.